### PR TITLE
Clean up the main wordle gameplay loop as well as tweak the scoring algorithm

### DIFF
--- a/Guess.java
+++ b/Guess.java
@@ -1,4 +1,3 @@
-import java.io.*;
 import java.util.*;
 
 public class Guess

--- a/Wordle.java
+++ b/Wordle.java
@@ -1,5 +1,8 @@
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class Wordle
 {
@@ -12,7 +15,7 @@ public class Wordle
 		Scanner in = new Scanner(System.in);
 		System.out.println("Is the goal word known?");
 
-		String answer = in.nextLine();
+		String answer = in.nextLine().strip();
 		boolean autoplay = (answer.equals("y") || answer.equals("yes"));
 		WordleSolver solver = getSolver(in);
 
@@ -28,25 +31,27 @@ public class Wordle
 
 	// =================================================================================
 
-	public static void autoplayKnownGoal(WordleSolver solver) throws Exception
+	public static void autoplayKnownGoal(WordleSolver solver)
 	{
 		Scanner in = new Scanner(System.in);
-
 		System.out.print("Enter goal word: ");
 		System.out.flush();
 
-		String goal = in.nextLine().strip().toLowerCase();
+		String goal = in.nextLine().strip().toUpperCase();
 		System.out.println("Goal: '" + goal + "'");
 
 		for (int i = 0; i < MAX_GUESSES; i++)
 		{
 			Guess guess = new Guess(solver.getNextGuessWord(), null);
 			guess.populateResultsAgainst(goal);
+
+			System.out.println("Guess #" + (i + 1) + ": " + guess.getWord());
+			System.out.println("Results: " + Utilities.stringFromResults(guess.getResults()));
 			solver.applyGuess(guess);
 
 			if (solver.hasWon())
 			{
-				System.out.println("SUCCESS!!!");
+				System.out.println("\nSUCCESS!!!");
 				System.out.println("Took " + (i + 1) + " guesses");
 				System.exit(0);
 			}
@@ -72,14 +77,15 @@ public class Wordle
 		for (int i = 0; i < MAX_GUESSES; i++)
 		{
 			String recommendedGuessWord = solver.getNextGuessWord();
+			System.out.println("Guess #" + (i + 1));
 			System.out.println("Recommended guess: '" + recommendedGuessWord + "'");
 			System.out.print("Enter your guess: ");
 			System.out.flush();
-			String guessWord = in.nextLine();
+			String guessWord = in.nextLine().strip();
 
 			System.out.print("Enter the result: ");
 			System.out.flush();
-			String resultString = in.nextLine();
+			String resultString = in.nextLine().strip();
 			Guess guess = new Guess(guessWord, Utilities.resultsFromString(resultString));
 
 			solver.applyGuess(guess);
@@ -115,7 +121,7 @@ public class Wordle
 
 			try
 			{
-				String input = in.nextLine();
+				String input = in.nextLine().strip();
 
 				if (input.equals(""))
 				{
@@ -140,43 +146,18 @@ public class Wordle
 		}
 
 		// initialize the chosen solver
-		if (choice == 0)
-		{
-			NoDupesSolver solver = (NoDupesSolver)solvers[choice];
-			solver.initialize(loadWords(new File("words5.txt")), true);
-		}
-
-		return solvers[choice];
-	}
-
-	// =================================================================================
-
-	public static ArrayList<String> loadWords(File file) throws Exception
-	{
-		Scanner in = new Scanner(file);
-		ArrayList<String> words = new ArrayList<String>(20000);
+		WordleSolver solverChoice = solvers[choice];
+		solverChoice.initialize(loadWords("wordle.txt"));
 		
-		while (in.hasNextLine())
-		{
-			words.add(in.nextLine().strip().toLowerCase());
-		}
-
-		return words;
+		return solverChoice;
 	}
 
 	// =================================================================================
-	// use for debugging with custom lists
-	public static ArrayList<String> loadWords2(File unused)
+	public static Set<String> loadWords(String fileName) throws Exception
 	{
-		ArrayList<String> words = new ArrayList<String>();
-		words.add("abhor");
-		words.add("abide");
-		words.add("abmho");
-		words.add("abnet");
-		words.add("abbey");
-
-		return words;
+		//Purposefully uppercase all the words
+		return Files.lines(Paths.get(fileName))
+				.map(String::toUpperCase)
+				.collect(Collectors.toSet());
 	}
-
-	// =================================================================================
 }

--- a/WordleSolver.java
+++ b/WordleSolver.java
@@ -1,12 +1,13 @@
-import java.io.*;
-import java.util.*;
+import java.util.Collection;
 
 public interface WordleSolver
 {
-	public String getName();
-	public boolean hasWon();
-	public String getNextGuessWord();
+	String getName();
+	boolean hasWon();
+	String getNextGuessWord();
 
 	// Requires guess.results to be filled out
-	public void applyGuess(Guess guess);
+	void applyGuess(Guess guess);
+
+	void initialize(Collection<String> words);
 }

--- a/allWords.txt
+++ b/allWords.txt
@@ -12299,8 +12299,6 @@ araphorostic
 arapunga
 Araquaju
 arar
-Arara
-arara
 araracanga
 ararao
 ararauna
@@ -57882,7 +57880,6 @@ drinker
 drinking
 drinkless
 drinkproof
-drinn
 drip
 dripper
 dripping
@@ -108453,7 +108450,6 @@ louisine
 louk
 Loukas
 loukoum
-loulu
 lounder
 lounderer
 lounge
@@ -128540,7 +128536,6 @@ nullisome
 nullisomic
 nullity
 nulliverse
-nullo
 Numa
 Numantine
 numb
@@ -130236,7 +130231,6 @@ oinomel
 oint
 ointment
 Oireachtas
-oisin
 oisivity
 oitava
 oiticica
@@ -131065,7 +131059,6 @@ oolak
 oolemma
 oolite
 oolitic
-oolly
 oologic
 oological
 oologically
@@ -182194,7 +182187,6 @@ sithement
 sithence
 sithens
 sitient
-sitio
 sitiology
 sitiomania
 sitiophobia
@@ -184695,8 +184687,6 @@ soliloquizing
 soliloquizingly
 soliloquy
 solilunar
-Solio
-solio
 soliped
 solipedal
 solipedous
@@ -218264,7 +218254,6 @@ uninjuriously
 uninjuriousness
 uninked
 uninlaid
-uninn
 uninnate
 uninnocence
 uninnocent
@@ -220001,7 +219990,6 @@ unoil
 unoiled
 unoiling
 unoily
-unold
 unomened
 unominous
 unomitted
@@ -225770,7 +225758,6 @@ urbanization
 urbanize
 urbarial
 urbian
-urbic
 Urbicolae
 urbicolous
 urbification

--- a/words5.txt
+++ b/words5.txt
@@ -536,8 +536,6 @@ arado
 arain
 arake
 Aramu
-Arara
-arara
 arati
 Araua
 Arawa
@@ -2648,7 +2646,6 @@ drier
 drift
 drill
 drink
-drinn
 drisk
 drive
 drogh
@@ -5983,7 +5980,6 @@ nucal
 nucha
 nucin
 nudge
-nullo
 numda
 numen
 nummi
@@ -6055,7 +6051,6 @@ ohelo
 ohmic
 oiled
 oiler
-oisin
 okapi
 okrug
 Olcha
@@ -6092,7 +6087,6 @@ onset
 ontal
 onymy
 oolak
-oolly
 oopak
 oopod
 ootid
@@ -6700,7 +6694,6 @@ prest
 prexy
 Price
 price
-prich
 prick
 pride
 pridy
@@ -7871,7 +7864,6 @@ sitao
 sitar
 sitch
 sithe
-sitio
 Sitka
 Sitta
 situs
@@ -8130,8 +8122,6 @@ solen
 soler
 soles
 solid
-Solio
-solio
 solod
 Solon
 solon
@@ -9180,7 +9170,6 @@ trona
 tronc
 trone
 troop
-troot
 trope
 troth
 trout
@@ -9410,7 +9399,6 @@ Uniat
 uniat
 unice
 unify
-uninn
 union
 unite
 unity
@@ -9437,7 +9425,6 @@ unmix
 unnew
 unode
 unoil
-unold
 Unona
 unorn
 unown
@@ -9522,7 +9509,6 @@ urase
 urate
 Urban
 urban
-urbic
 urdee
 ureal
 Uredo


### PR DESCRIPTION
- Implement a character count when scoring a word against a known word. This allows letters that appear more than once to be both green and yellow. This behavior matches the wordle site itself
- Sanitize inputs in the main method as well as convert all words to UPPERCASE for posterity
- Remove the `public` modifier from the `WordleSolver` interface methods. All interface methods are public by default
- Instead of relying on a constructor and instantiating all solvers at the same time, define an `initialize(...)` method in `WordleSolver` that takes in a `Collection<String>` representing the words and then does whatever it needs to internally. This ensures that only the chosen solver will initialize, saving time
- 